### PR TITLE
remove mux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,4 @@ module github.com/AshokShau/upi-qr-generator
 
 go 1.23.2
 
-require (
-	github.com/gorilla/mux v1.8.1
-	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e
-)
+require github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
-github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e h1:MRM5ITcdelLK2j1vwZ3Je0FKVCfqOLp5zO6trqMLYs0=
 github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e/go.mod h1:XV66xRDqSt+GTGFMVlhk3ULuV0y9ZmzeVGR4mloJI3M=

--- a/main.go
+++ b/main.go
@@ -6,17 +6,13 @@ import (
 	"net/http"
 
 	"github.com/AshokShau/upi-qr-generator/str"
-	"github.com/gorilla/mux"
 )
 
 func main() {
-	r := mux.NewRouter()
+	http.HandleFunc("/", str.Home)
+	http.HandleFunc("/qr", str.GenerateQRCodeHandler)
+	http.HandleFunc("/pay", str.RenderPaymentPageHandler)
 
-	r.HandleFunc("/", str.Home)
-	r.HandleFunc("/qr", str.GenerateQRCodeHandler).Methods("GET")
-	r.HandleFunc("/pay", str.RenderPaymentPageHandler).Methods("GET")
-	r.PathPrefix("/static/").Handler(http.StripPrefix("/static/", http.FileServer(http.Dir("./static"))))
-
-	fmt.Println("Server started at http://localhost:3000")
-	log.Fatal(http.ListenAndServe(":3000", r))
+	fmt.Println("Server started on port 3000")
+	log.Fatal(http.ListenAndServe(":3000", nil))
 }

--- a/vercel.json
+++ b/vercel.json
@@ -4,8 +4,7 @@
     {
       "src": "/api/*.go",
       "use": "@vercel/go"
-    },
-    { "src": "static/*", "use": "@vercel/static"}
+    }
   ],
   "rewrites": [
     { "source": "/", "destination": "/api/index.go" },


### PR DESCRIPTION
## Summary by Sourcery

Remove Gorilla Mux and switch to using the default net/http package for routing, simplifying the codebase and reducing dependencies. Update vercel.json to reflect changes in static file handling.

Enhancements:
- Replace Gorilla Mux with the default net/http package for routing.

Build:
- Remove Gorilla Mux dependency from go.mod.

Deployment:
- Update vercel.json to remove static file handling configuration.